### PR TITLE
certificates: fix firefox on windows

### DIFF
--- a/PagarMe.Bifrost.Certificates/certificates-windows-firefox-store.bat
+++ b/PagarMe.Bifrost.Certificates/certificates-windows-firefox-store.bat
@@ -1,4 +1,4 @@
 @echo off
 
-certutil.exe -d %1 -D -n %3
-certutil.exe -d %1 -A -n %3 -i %2\%3.crt -t "%4"
+certutil.exe -d "%1" -D -n %3
+certutil.exe -d "%1" -A -n %3 -i %2\%3.crt -t "%4"


### PR DESCRIPTION
When a user folder has spaces, the command would be broken

closes https://github.com/pagarme/mundo-fisico/issues/624