### PR TITLE
certificates: fix bat to install on firefox

### DIFF
--- a/PagarMe.Bifrost.Certificates/certificates-windows-firefox-store.bat
+++ b/PagarMe.Bifrost.Certificates/certificates-windows-firefox-store.bat
@@ -1,4 +1,4 @@
 @echo off
 
 certutil.exe -d "%1" -D -n %3
-certutil.exe -d "%1" -A -n %3 -i %2\%3.crt -t "%4"
+certutil.exe -d "%1" -A -n %3 -i "%2\%3.crt" -t "%4"


### PR DESCRIPTION
If the path has spaces, the script will break